### PR TITLE
Investigate superannuation app access button

### DIFF
--- a/SUPERANNUATION_ACCESS.md
+++ b/SUPERANNUATION_ACCESS.md
@@ -1,0 +1,81 @@
+# Accessing the Superannuation Tracker App
+
+## Overview
+The workspace now contains **two applications**:
+
+1. **Budget Command Centre** - The main family budget management app (root directory)
+2. **Superannuation Tracker** - A dedicated React app for retirement planning (`/client/` directory)
+
+## How to Access the Superannuation App
+
+### Option 1: Via the Navigation Button (Recommended)
+1. Open the Budget Command Centre app (main `index.html`)
+2. Look for the **"🏦 Superannuation Tracker"** button in the navigation bar
+3. Click the button to open the Superannuation Tracker in a new window/tab
+
+### Option 2: Direct Access
+You can also run the Superannuation Tracker directly:
+
+#### Development Mode
+```bash
+# Terminal 1: Start the backend server (from root directory)
+npm start
+# Or for auto-restart on changes:
+npm run dev
+
+# Terminal 2: Start the React frontend
+npm run client
+```
+
+The apps will run on:
+- Budget App: `http://localhost:5000` (or whichever port you're using)
+- Superannuation App: `http://localhost:3000`
+
+#### Production Mode
+```bash
+# Build the client
+npm run client-build
+
+# Start the server
+npm start
+```
+
+## What Changed
+- **Added** a new navigation button "🏦 Superannuation Tracker" to the main Budget app
+- **Added** JavaScript handler to open the React app in a new window
+- **Added** special styling (purple theme) to make the button stand out
+- The button intelligently detects if you're in development (opens `localhost:3000`) or production mode
+
+## Features of the Superannuation Tracker
+- 📊 Dashboard with personal details and current balance
+- 📈 Projection Calculator with compound growth visualization
+- 💰 Retirement Income Calculator with withdrawal strategies
+- 🧾 Tax Benefits Calculator for concessional contributions
+- 📉 Minimum Drawdown Calculator with age-based requirements
+
+## Troubleshooting
+
+### "Can't connect to localhost:3000"
+Make sure the React app is running:
+```bash
+cd client
+npm install  # if not already done
+npm start
+```
+
+### Button doesn't appear
+1. Clear your browser cache
+2. Make sure you're viewing the main Budget app (`index.html` in root)
+3. Check browser console for JavaScript errors
+
+### React app won't start
+Make sure dependencies are installed:
+```bash
+npm run install-all
+```
+
+Or manually:
+```bash
+cd client
+npm install
+```

--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
       <button class="nav-btn" data-view="categories">Category Manager</button>
       <button class="nav-btn" data-view="tax">💰 Tax Hub</button>
       <button class="nav-btn" data-view="ai-insights">🤖 AI Insights</button>
+      <button class="nav-btn" id="superannuationAppBtn">🏦 Superannuation Tracker</button>
     </nav>
 
     <main id="app" class="app">

--- a/main.js
+++ b/main.js
@@ -121,6 +121,9 @@ function initNavigation() {
     button.addEventListener('click', () => {
       const viewId = button.getAttribute('data-view');
       
+      // Skip if this is a special button without data-view attribute
+      if (!viewId) return;
+      
       navButtons.forEach(btn => btn.classList.remove('active'));
       views.forEach(view => view.classList.remove('active'));
       
@@ -128,6 +131,20 @@ function initNavigation() {
       document.getElementById(`${viewId}-view`).classList.add('active');
     });
   });
+  
+  // Add handler for Superannuation Tracker button
+  const superBtn = document.getElementById('superannuationAppBtn');
+  if (superBtn) {
+    superBtn.addEventListener('click', () => {
+      // Open the React superannuation app
+      // In development, the React app runs on port 3000
+      // In production, adjust this URL to where the app is deployed
+      const superAppUrl = window.location.hostname === 'localhost' 
+        ? 'http://localhost:3000' 
+        : '/superannuation';
+      window.open(superAppUrl, '_blank');
+    });
+  }
 }
 
 // ==================== Chart Utilities ====================

--- a/styles.css
+++ b/styles.css
@@ -90,6 +90,17 @@ body {
   border-color: rgba(56, 189, 248, 0.6);
 }
 
+/* Special styling for superannuation button */
+#superannuationAppBtn {
+  background: rgba(147, 51, 234, 0.15);
+  border-color: rgba(147, 51, 234, 0.4);
+}
+
+#superannuationAppBtn:hover {
+  background: rgba(147, 51, 234, 0.25);
+  border-color: rgba(147, 51, 234, 0.6);
+}
+
 /* Button styles */
 .btn-primary, .btn-secondary {
   padding: 0.6rem 1.2rem;


### PR DESCRIPTION
Add a navigation button to the main budget app to access the separate Superannuation Tracker app.

The Superannuation Tracker app existed as a separate React application but was not linked or accessible from the main Budget Command Centre UI. This PR integrates an access point for it.

---
<a href="https://cursor.com/background-agent?bcId=bc-a3aab532-698d-4cb0-b508-5d65be67ab94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a3aab532-698d-4cb0-b508-5d65be67ab94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

