### PR TITLE
Fix broken superannuation repository link

### DIFF
--- a/main.js
+++ b/main.js
@@ -138,9 +138,9 @@ function initNavigation() {
     superBtn.addEventListener('click', () => {
       // Open the React superannuation app
       // In development, the React app runs on port 3000
-      // In production, it's deployed to GitHub Pages
+      // In production, it's deployed to GitHub Pages at Budget---old-2 repository
       const isLocal = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
-      const superAppUrl = isLocal ? 'http://localhost:3000' : '/superannuation/app';
+      const superAppUrl = isLocal ? 'http://localhost:3000' : 'https://stevencowell.github.io/Budget---old-2/';
       window.open(superAppUrl, '_blank');
     });
   }


### PR DESCRIPTION
Update Superannuation Tracker button URL to the correct GitHub Pages repository link.

---
<a href="https://cursor.com/background-agent?bcId=bc-f69e53e0-4c3c-44df-9da3-ee58e8431caf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f69e53e0-4c3c-44df-9da3-ee58e8431caf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

