### PR TITLE
Fix superannuation button redirect

### DIFF
--- a/SUPERANNUATION_BUTTON_FIX.md
+++ b/SUPERANNUATION_BUTTON_FIX.md
@@ -1,0 +1,69 @@
+# Superannuation Button Fix
+
+## Issue
+The Superannuation Tracker button was causing the page to flick back to the overview instead of opening the superannuation app in a new window.
+
+## Root Cause
+The superannuation button has the class `.nav-btn` which caused it to be processed by the general navigation event handler. Even though the handler had a check to skip buttons without a `data-view` attribute, the event was still propagating and potentially interfering with the navigation state.
+
+## Solution
+Added `e.stopPropagation()` to the superannuation button's click handler to prevent event bubbling that could interfere with the navigation system.
+
+### Changes Made to `/workspace/main.js`
+
+**Before:**
+```javascript
+const superBtn = document.getElementById('superannuationAppBtn');
+if (superBtn) {
+  superBtn.addEventListener('click', () => {
+    // Open the React superannuation app
+    const isLocal = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
+    const superAppUrl = isLocal ? 'http://localhost:3000' : 'https://stevencowell.github.io/Budget---old-2/';
+    window.open(superAppUrl, '_blank');
+  });
+}
+```
+
+**After:**
+```javascript
+const superBtn = document.getElementById('superannuationAppBtn');
+if (superBtn) {
+  superBtn.addEventListener('click', (e) => {
+    // Prevent the default nav-btn behavior
+    e.stopPropagation();
+    
+    // Open the React superannuation app
+    const isLocal = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
+    const superAppUrl = isLocal ? 'http://localhost:3000' : 'https://stevencowell.github.io/Budget---old-2/';
+    window.open(superAppUrl, '_blank');
+  });
+}
+```
+
+## How It Works Now
+
+1. User clicks the "🏦 Superannuation Tracker" button
+2. The superannuation-specific event handler fires first
+3. `e.stopPropagation()` prevents the event from bubbling up
+4. The general navigation handler doesn't process this button
+5. The React app opens in a new window/tab
+6. The current page stays on whatever view was active
+
+## Testing
+
+### Local Development
+1. Start the React app: `npm run client` (runs on http://localhost:3000)
+2. Open the main Budget app in a browser
+3. Click "🏦 Superannuation Tracker"
+4. The React app should open in a new tab at localhost:3000
+
+### Production
+1. Visit the deployed Budget app
+2. Click "🏦 Superannuation Tracker"  
+3. The React app should open in a new tab at https://stevencowell.github.io/Budget---old-2/
+
+## Related Files
+- `/workspace/index.html` - Contains the button markup (line 33)
+- `/workspace/main.js` - Contains the navigation logic (lines 116-150)
+- `/workspace/styles.css` - Contains button styling (lines 94-102)
+- `/workspace/SUPERANNUATION_ACCESS.md` - Documentation on how to access the app

--- a/main.js
+++ b/main.js
@@ -121,7 +121,7 @@ function initNavigation() {
     button.addEventListener('click', () => {
       const viewId = button.getAttribute('data-view');
       
-      // Skip if this is a special button without data-view attribute
+      // Skip if this is a special button without data-view attribute (e.g., superannuation button)
       if (!viewId) return;
       
       navButtons.forEach(btn => btn.classList.remove('active'));
@@ -135,7 +135,10 @@ function initNavigation() {
   // Add handler for Superannuation Tracker button
   const superBtn = document.getElementById('superannuationAppBtn');
   if (superBtn) {
-    superBtn.addEventListener('click', () => {
+    superBtn.addEventListener('click', (e) => {
+      // Prevent the default nav-btn behavior
+      e.stopPropagation();
+      
       // Open the React superannuation app
       // In development, the React app runs on port 3000
       // In production, it's deployed to GitHub Pages at Budget---old-2 repository


### PR DESCRIPTION
Prevent event bubbling on the superannuation button to correctly open the app instead of reverting to the overview.

The superannuation button, despite having a dedicated click handler, was also being processed by a general navigation handler due to its `.nav-btn` class. This caused event interference, leading to the page flickering back to the overview. Adding `e.stopPropagation()` ensures that only the specific handler for the superannuation button is executed.

---
<a href="https://cursor.com/background-agent?bcId=bc-c5e96d81-1996-4c5e-9f8a-753ae0fce97c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c5e96d81-1996-4c5e-9f8a-753ae0fce97c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

